### PR TITLE
Some Dockerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,42 +2,53 @@ FROM ubuntu:16.04
 MAINTAINER Wah Loon Keng <kengzwl@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
-RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
-# General dependencies
-RUN apt-get update
-RUN apt-get install -y git nano curl wget software-properties-common build-essential
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
-RUN apt-get install -y nodejs
-RUN apt-get install -y python3-dev python3-pip python3-setuptools
-RUN apt-get install -y mysql-server
+# Get latest Node 6 install script and save it to /tmp
+ADD https://raw.githubusercontent.com/nodesource/distributions/master/deb/setup_6.x /tmp/node6_setup.sh
 
-# Install Nginx, supervisor, monitoring tools
-RUN apt-get install -y nginx supervisor dialog net-tools
+# Run node installer script to prepare apt-get for later install
+RUN cat /tmp/node6_setup.sh | bash \
+    &&  apt-get update \
+    && apt-get install -y build-essential \
+    dialog \
+    git \
+    net-tools \
+    nodejs \
+    nginx \
+    postgresql \
+    postgresql-contrib \
+    python3-dev \
+    python3-pip \
+    python3-setuptools \
+    software-properties-common \
+    supervisor \
+    && rm -rf /var/lib/apt/lists/*
+
 # Replace the default Nginx configuration file
-RUN rm -v /etc/nginx/nginx.conf
-ADD config/nginx.conf /etc/nginx/
+# RUN rm -v /etc/nginx/nginx.conf
+COPY config/nginx.conf /etc/nginx/
+
 # Add a supervisor configuration file
-ADD config/supervisord.conf /etc/supervisor/conf.d/
+COPY config/supervisord.conf /etc/supervisor/conf.d/
 
 # Define mountable directories
 VOLUME ["/var/log"]
 
 # Define working directory
 RUN mkdir -p /var/www/aiva
-WORKDIR /var/www/aiva
 
-ADD package.json ./
-RUN npm i
-ADD . /var/www/aiva
-RUN npm run setup
+WORKDIR /var/www/aiva
+COPY package.json ./
+COPY . ./
+RUN sed -i s/peer/trust/ /etc/postgresql/9.5/main/pg_hba.conf && /etc/init.d/postgresql restart
+RUN ["/bin/bash", "-c", "npm i && npm run setup"]
 
 # expose ports for prod/dev, see config/
 # the ports on the left of each is the surrogate port for nginx redirection
 EXPOSE 4039 4040 4038 4041 7472 7474 7475 7476 6463 6464 6465 6466
 
 # default command on creating a new container
-# CMD service mysql start && NPM_RUN="development" supervisord
+# CMD service mysql start && NPM_RUN="development" supervisor
 
 # useful Docker commands
 # build: docker build -t kengz/aiva .

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN ["/bin/bash", "-c", "npm i && npm run setup"]
 EXPOSE 4039 4040 4038 4041 7472 7474 7475 7476 6463 6464 6465 6466
 
 # default command on creating a new container
-# CMD service mysql start && NPM_RUN="development" supervisor
+# CMD service mysql start && NPM_RUN="development" supervisord
 
 # useful Docker commands
 # build: docker build -t kengz/aiva .

--- a/bin/start
+++ b/bin/start
@@ -15,10 +15,10 @@ fi
 
 if [[ $1 && $1=='production' ]]; then
   container=aiva-production
-  COMMAND="docker run -m 4G -it -d -p 4040:4039 -p 7474:7472 -p 6464:6463 --name $container $CLOUDDREAM_LINK_VOL -v `pwd`:/var/www/aiva kengz/aiva /bin/bash -c 'service mysql start && NPM_RUN=\"production\" supervisord'"
+  COMMAND="docker run -m 4G -it -d -p 4040:4039 -p 7474:7472 -p 6464:6463 --name $container $CLOUDDREAM_LINK_VOL -v `pwd`:/var/www/aiva kengz/aiva /bin/bash -c 'service postgresql start && NPM_RUN=\"production\" supervisord'"
 else
   container=aiva-development
-  COMMAND="docker run -m 4G -it -p 4041:4038 -p 7476:7475 -p 6466:6465 --name $container $CLOUDDREAM_LINK_VOL -v `pwd`:/var/www/aiva kengz/aiva /bin/bash -c 'service mysql start && NPM_RUN=\"development\" $SHELL'"
+  COMMAND="docker run -m 4G -it -p 4041:4038 -p 7476:7475 -p 6466:6465 --name $container $CLOUDDREAM_LINK_VOL -v `pwd`:/var/www/aiva kengz/aiva /bin/bash -c 'service postgresql start && NPM_RUN=\"development\" $SHELL'"
 fi
 
 if [[ "$(docker images -q kengz/aiva:latest 2> /dev/null)" != "" ]]; then


### PR DESCRIPTION
The existing Dockerfile could use a little bit of Dockerization. This still does not solve the issue with postgresql not working with `npm run start` on build, but it's a start. You can `run bash` into the last image, start postgres and `psql -U postgres` works. But.... This really should be a composed docker. NodeJS in one container, `nginx` in another container and `postgresql` in a 3rd. Working on that part, and possibly moving to another not-as-heavy base image for everything to run in.